### PR TITLE
[FIX] Analytic account fix in multicompanies env

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4318,7 +4318,7 @@ class AccountMoveLine(models.Model):
             'ref': self.ref,
             'move_id': self.id,
             'user_id': self.move_id.invoice_user_id.id or self._uid,
-            'company_id': distribution.account_id.company_id.id or self.env.company.id,
+            'company_id': distribution.account_id.company_id.id or self.move_id.company_id.id or self.env.company.id,
         }
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

- Create an analytic tag with no company
- Set a 100% distribution on an analytic account with no company
- Create a journal entry on Company A and use this analytic tag
- Switch the companies as follows :
- Write : Company B
- Read : Company A
- Post the journal entry, blocing message : Incompatible companies on records

Desired behavior after PR is merged:

- The same behavior as we use the analytic account instead of the analytic tag

OPW-2900827

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
